### PR TITLE
New class NzRayPicking

### DIFF
--- a/include/Nazara/Graphics.hpp
+++ b/include/Nazara/Graphics.hpp
@@ -56,6 +56,7 @@
 #include <Nazara/Graphics/LightManager.hpp>
 #include <Nazara/Graphics/Material.hpp>
 #include <Nazara/Graphics/Model.hpp>
+#include <Nazara/Graphics/RayPicking.hpp>
 #include <Nazara/Graphics/RenderTechniques.hpp>
 #include <Nazara/Graphics/Scene.hpp>
 #include <Nazara/Graphics/SceneLayer.hpp>

--- a/include/Nazara/Graphics/RayPicking.hpp
+++ b/include/Nazara/Graphics/RayPicking.hpp
@@ -1,0 +1,76 @@
+// Copyright (C) 2014 Gawaboumga (Youri Hubaut) - Jérôme Leclercq
+// This file is part of the "Nazara Engine - Graphics module"
+// For conditions of distribution and use, see copyright notice in Config.hpp
+
+#pragma once
+
+#ifndef NAZARA_RAYPICKING_HPP
+#define NAZARA_RAYPICKING_HPP
+
+#include <Nazara/Graphics/Camera.hpp>
+#include <Nazara/Graphics/SceneNode.hpp>
+#include <Nazara/Math/Ray.hpp>
+#include <Nazara/Math/Vector2.hpp>
+#include <Nazara/Math/Vector3.hpp>
+#include <Nazara/Utility/Node.hpp>
+#include <map>
+#include <limits>
+
+
+
+		// I think the name of the methods could be longer :)
+
+
+
+//! NzRayPicking provides methods to find NzSceneNodes below the mouse position.
+/** Methods offers to find each NzSceneNodes or only one in your scene based on the mouse position on the screen.
+It can also do the opposite: project a 3D position on the screen to get the mouse coordinates. */
+class NAZARA_API NzRayPicking
+{
+	public:
+		NzRayPicking() = default;
+		~NzRayPicking() = default;
+
+		//! Returns a map of each nodes who is below the mouse position (key: distance -> nearest to the farthest).
+		/** Nodes, that are traversed by the ray emitted by camera in the direction of the mouse position, are stocked in a
+		map whose key is the distance between the first collision (with AABB test) and the camera. Map are sorted by std::less,
+		thus closer the object is, closer to the beginning of the map will be.
+			\param mousePosition: mouse position (not normalized).
+			\param camera: active camera.
+			\param root: which children will be test.
+			\param maxDistance: maximal distance for the collision point.
+			\return map of sorted NzSceneNode by distance. */
+		static std::map<float, NzSceneNode*> GetEverySceneNodeFromMousePosition(const NzVector2i& mousePosition, const NzCamera& camera, const NzNode* root, float maxDistance = std::numeric_limits<float>::infinity());
+
+		//! Projects a 3D position on a mouse position.
+		/** There are rounding issues (edges of the screen can have overflowed values).
+			\param position3D: position to project.
+			\param camera: active camera.
+			\return mouse position (not normalized). */
+		static NzVector2i GetMousePositionFrom3DCoordinates(const NzVector3f& position3D, const NzCamera& camera);
+
+		//! Returns the ray emitted by camera in the direction of the mouse position.
+		/** Mainly used for GetEverySceneNodeFromMousePosition() and GetSceneNodeFromMousePosition().
+			\param mousePosition: mouse position (not normalized).
+			\param camera: active camera.
+			\return ray emitted. */
+		static NzRayf GetRayFromMousePosition(const NzVector2i& mousePosition, const NzCamera& camera);
+
+		//! Returns the first hit node who is below the mouse position.
+		/** First hit node (with AABB test)
+			\param mousePosition: mouse position (not normalized).
+			\param camera: active camera.
+			\param root: which children will be test.
+			\param maxDistance: maximal distance for the collision point.
+			\return first NzSceneNode hit. */
+		static NzSceneNode* GetSceneNodeFromMousePosition(const NzVector2i& mousePosition, const NzCamera& camera, const NzNode* root, float maxDistance = std::numeric_limits<float>::infinity());
+
+	private:
+		static void RecursiveRayPicking(const NzRayf& ray, const NzCamera& camera, const NzNode* root);
+
+		static std::map<float, NzSceneNode*> m_lastPicked;
+		static float m_distance;
+		static float m_maxDistance;
+};
+
+#endif // NAZARA_RAYPICKING_HPP

--- a/src/Nazara/Graphics/RayPicking.cpp
+++ b/src/Nazara/Graphics/RayPicking.cpp
@@ -1,0 +1,135 @@
+// Copyright (C) 2014 Gawaboumga (Youri Hubaut) - Jérôme Leclercq
+// This file is part of the "Nazara Engine - Graphics module"
+// For conditions of distribution and use, see copyright notice in Config.hpp
+
+#include <Nazara/Graphics/RayPicking.hpp>
+#include <Nazara/Math/Algorithm.hpp>
+#include <Nazara/Graphics/Debug.hpp>
+
+std::map<float, NzSceneNode*> NzRayPicking::m_lastPicked = std::map<float, NzSceneNode*>();
+float NzRayPicking::m_distance = std::numeric_limits<float>::infinity();
+float NzRayPicking::m_maxDistance = std::numeric_limits<float>::infinity();
+
+std::map<float, NzSceneNode*> NzRayPicking::GetEverySceneNodeFromMousePosition(const NzVector2i& mousePosition, const NzCamera& camera, const NzNode* root, float maxDistance)
+{
+	NzRayf ray = GetRayFromMousePosition(mousePosition, camera);
+
+	m_maxDistance = maxDistance;
+	m_lastPicked.clear();
+
+	RecursiveRayPicking(ray, camera, root);
+
+	return m_lastPicked;
+}
+
+NzVector2i NzRayPicking::GetMousePositionFrom3DCoordinates(const NzVector3f& position3D, const NzCamera& camera)
+{
+	NzVector3f transformedPosition = (camera.GetViewMatrix() * camera.GetProjectionMatrix()).Transform(position3D);
+
+	if (transformedPosition.z < 0.f)
+	{
+		#ifdef NAZARA_DEBUG
+		NazaraError("Failed to transform 3D coordinates to screen coordinates");
+		#endif
+
+		return NzVector2i(std::numeric_limits<int>::infinity(), std::numeric_limits<int>::infinity()); // What to do ?
+	}
+	else
+	{
+		NzVector2f viewPort = NzVector2f(camera.GetViewport().GetLengths()) / 2.f;
+
+		float zDepth = 1.f;
+		if (!NzNumberEquals(transformedPosition.z, 0.f))
+			zDepth = 1.f / transformedPosition.z; // precision error
+
+		return NzVector2i(viewPort.x + viewPort.x * transformedPosition.x * zDepth,
+						  viewPort.y - viewPort.y * transformedPosition.y * zDepth);
+	}
+}
+
+NzRayf NzRayPicking::GetRayFromMousePosition(const NzVector2i& mousePosition, const NzCamera& camera)
+{
+	NzVector3f view = camera.GetForward();
+	view.Normalize();
+
+	NzVector3f horizontal = camera.GetRight();
+	horizontal.Normalize();
+
+	NzVector3f vertical = NzVector3f::CrossProduct(horizontal, view); // camera.GetUp() ?
+	vertical.Normalize();
+
+	vertical *= (camera.GetFrustum().GetCorner(nzCorner_NearLeftBottom) - camera.GetFrustum().GetCorner(nzCorner_NearLeftTop)).GetLength(); // Real vertical length of the frustum's near plane.
+	horizontal *= (camera.GetFrustum().GetCorner(nzCorner_NearLeftBottom) - camera.GetFrustum().GetCorner(nzCorner_NearRightBottom)).GetLength(); // Real horizontal length of the frustum's near plane.
+
+	float x = mousePosition.x;
+	float y = mousePosition.y;
+
+	x /= camera.GetViewport().width;
+	y /= camera.GetViewport().height; // mouse position "normalized"
+
+	NzRayf ray;
+	ray.origin = camera.GetPosition();
+	// We convert upper left coordinates to the middle ones.
+	ray.direction = ((x - 0.5f) * horizontal + ((1.f - 2.f * y)/2.f) * vertical + view * camera.GetZNear()).Normalize();
+
+	return ray;
+}
+
+NzSceneNode* NzRayPicking::GetSceneNodeFromMousePosition(const NzVector2i& mousePosition, const NzCamera& camera, const NzNode* root, float maxDistance)
+{
+	NzRayf ray = GetRayFromMousePosition(mousePosition, camera);
+
+	m_maxDistance = maxDistance;
+	m_lastPicked.clear();
+
+	RecursiveRayPicking(ray, camera, root);
+
+	if (m_lastPicked.empty())
+		return nullptr;
+	else
+		return m_lastPicked.begin()->second;
+}
+
+void NzRayPicking::RecursiveRayPicking(const NzRayf& ray, const NzCamera& camera, const NzNode* node)
+{
+	for (NzNode* child : node->GetChilds())
+	{
+		if (child->GetNodeType() == nzNodeType_Scene)
+		{
+			NzSceneNode* sceneNode = static_cast<NzSceneNode*>(child);
+
+			if (sceneNode->IsVisible())
+			{
+				float closestPoint;
+				float farthestPoint;
+
+				if (ray.Intersect(sceneNode->GetBoundingVolume().aabb, &closestPoint, &farthestPoint))
+				{
+					if (!m_lastPicked.empty())
+					{
+						float minDistance = std::min(closestPoint, farthestPoint);
+
+						if (minDistance < m_maxDistance)
+						{
+							m_distance = minDistance;
+							m_lastPicked[m_distance] = sceneNode;
+						}
+					}
+					else
+					{
+						float minDistance = std::min(std::min(m_distance, closestPoint), std::min(m_distance, farthestPoint));
+
+						if (minDistance < m_maxDistance)
+						{
+							m_distance = minDistance;
+							m_lastPicked[m_distance] = sceneNode;
+						}
+					}
+				}
+			}
+		}
+
+		if (child->HasChilds())
+			RecursiveRayPicking(ray, camera, node);
+	}
+}


### PR DESCRIPTION
New class to pick a node using the ray method.

The names of the methods should be changed !

- GetEverySceneNodeFromMousePosition(): Gets every nodes below the mouse
position.
- GetMousePositionFrom3DCoordinates(): Projects a 3D position to the
screen.
- GetRayFromMousePosition(): Returns the ray emitted by camera in the
direction of the mouse position.
- GetSceneNodeFromMousePosition(): Returns the first hit node who is
below the mouse position.