### PR TITLE
Suppression of warnings

### DIFF
--- a/include/Nazara/Core/OffsetOf.hpp
+++ b/include/Nazara/Core/OffsetOf.hpp
@@ -16,7 +16,7 @@ template <typename T, typename M> M NzImplGetMemberType(M T::*);
 template <typename T, typename R, R T::*M>
 constexpr std::size_t NzImplOffsetOf()
 {
-	return reinterpret_cast<std::size_t>(&(((T*)0)->*M));
+	return reinterpret_cast<std::size_t>(&((static_cast<T*>(0))->*M));
 }
 
 #define NzOffsetOf(type, member) NzImplOffsetOf<decltype(NzImplGetClassType(&type::member)), decltype(NzImplGetMemberType(&type::member)), &type::member>()

--- a/include/Nazara/Core/Updatable.hpp
+++ b/include/Nazara/Core/Updatable.hpp
@@ -9,9 +9,12 @@
 
 #include <Nazara/Prerequesites.hpp>
 
-class NzUpdatable
+class NAZARA_API NzUpdatable
 {
 	public:
+		NzUpdatable() = default;
+		virtual ~NzUpdatable();
+
 		virtual void Update() = 0;
 };
 

--- a/include/Nazara/Graphics/Drawable.hpp
+++ b/include/Nazara/Graphics/Drawable.hpp
@@ -13,7 +13,7 @@ class NAZARA_API NzDrawable
 {
 	public:
 		NzDrawable() = default;
-		~NzDrawable();
+		virtual ~NzDrawable();
 
 		virtual void Draw() const = 0;
 };

--- a/include/Nazara/Math/Vector2.inl
+++ b/include/Nazara/Math/Vector2.inl
@@ -51,19 +51,7 @@ NzVector2<T>::NzVector2(const NzVector4<T>& vec)
 template<typename T>
 T NzVector2<T>::AbsDotProduct(const NzVector2& vec) const
 {
-	return std::fabs(x * vec.x) + std::fabs(y * vec.y);
-}
-
-template<>
-inline int NzVector2<int>::AbsDotProduct(const NzVector2<int>& vec) const
-{
-	return std::labs(x * vec.x) + std::labs(y * vec.y);
-}
-
-template<>
-inline unsigned int NzVector2<unsigned int>::AbsDotProduct(const NzVector2<unsigned int>& vec) const
-{
-	return std::labs(x * vec.x) + std::labs(y * vec.y);
+	return std::abs(x * vec.x) + std::abs(y * vec.y);
 }
 
 template<typename T>

--- a/include/Nazara/Math/Vector3.inl
+++ b/include/Nazara/Math/Vector3.inl
@@ -57,19 +57,7 @@ NzVector3<T>::NzVector3(const NzVector4<T>& vec)
 template<typename T>
 T NzVector3<T>::AbsDotProduct(const NzVector3& vec) const
 {
-	return std::fabs(x * vec.x) + std::fabs(y * vec.y) + std::fabs(z * vec.z);
-}
-
-template<>
-inline int NzVector3<int>::AbsDotProduct(const NzVector3<int>& vec) const
-{
-	return std::labs(x * vec.x) + std::labs(y * vec.y) + std::labs(z * vec.z);
-}
-
-template<>
-inline unsigned int NzVector3<unsigned int>::AbsDotProduct(const NzVector3<unsigned int>& vec) const
-{
-	return std::labs(x * vec.x) + std::labs(y * vec.y) + std::labs(z * vec.z);
+	return std::abs(x * vec.x) + std::abs(y * vec.y) + std::abs(z * vec.z);
 }
 
 template<typename T>

--- a/include/Nazara/Math/Vector4.inl
+++ b/include/Nazara/Math/Vector4.inl
@@ -70,19 +70,7 @@ NzVector4<T>::NzVector4(const NzVector4<U>& vec)
 template<typename T>
 T NzVector4<T>::AbsDotProduct(const NzVector4& vec) const
 {
-	return std::fabs(x * vec.x) + std::fabs(y * vec.y) + std::fabs(z * vec.z) + std::fabs(w * vec.w);
-}
-
-template<>
-inline int NzVector4<int>::AbsDotProduct(const NzVector4<int>& vec) const
-{
-	return std::labs(x * vec.x) + std::labs(y * vec.y) + std::labs(z * vec.z) + std::labs(w * vec.w);
-}
-
-template<>
-inline unsigned int NzVector4<unsigned int>::AbsDotProduct(const NzVector4<unsigned int>& vec) const
-{
-	return std::labs(x * vec.x) + std::labs(y * vec.y) + std::labs(z * vec.z) + std::labs(w * vec.w);
+	return std::abs(x * vec.x) + std::abs(y * vec.y) + std::abs(z * vec.z) + std::abs(w * vec.w);
 }
 
 template<typename T>

--- a/include/Nazara/Utility/AbstractAtlas.hpp
+++ b/include/Nazara/Utility/AbstractAtlas.hpp
@@ -35,7 +35,7 @@ class NAZARA_API NzAbstractAtlas
 
 		void RemoveListener(Listener* font) const;
 
-		class Listener
+		class NAZARA_API Listener
 		{
 			public:
 				Listener() = default;

--- a/src/Nazara/Core/Updatable.cpp
+++ b/src/Nazara/Core/Updatable.cpp
@@ -1,0 +1,8 @@
+// Copyright (C) 2015 Jérôme Leclercq
+// This file is part of the "Nazara Engine - Core module"
+// For conditions of distribution and use, see copyright notice in Config.hpp
+
+#include <Nazara/Core/Updatable.hpp>
+#include <Nazara/Core/Debug.hpp>
+
+NzUpdatable::~NzUpdatable() = default;

--- a/src/Nazara/Utility/Buffer.cpp
+++ b/src/Nazara/Utility/Buffer.cpp
@@ -297,4 +297,4 @@ void NzBuffer::Uninitialize()
 	std::memset(s_bufferFactories, 0, (nzDataStorage_Max+1)*sizeof(NzBuffer::BufferFactory));
 }
 
-NzBuffer::BufferFactory NzBuffer::s_bufferFactories[nzDataStorage_Max+1] = {0};
+NzBuffer::BufferFactory NzBuffer::s_bufferFactories[nzDataStorage_Max+1] = {nullptr};

--- a/src/Nazara/Utility/Image.cpp
+++ b/src/Nazara/Utility/Image.cpp
@@ -809,7 +809,7 @@ NzVector3ui NzImage::GetSize(nzUInt8 level) const
 	if (level >= m_sharedImage->levelCount)
 	{
 		NazaraError("Level out of bounds (" + NzString::Number(level) + " >= " + NzString::Number(m_sharedImage->levelCount) + ')');
-		return 0;
+		return NzVector3ui::Zero();
 	}
 	#endif
 


### PR DESCRIPTION
OffsetOf: use of static_cast
Updatable: API and virtual destructor
Drawable: virtual destructor
Vector: std::abs should be "the" abs.
AbstractClass: API
+Updatable: Like for others abstracts
Buffer: nullptr for pointer to function.
Image: wasn't returning a vector.

Je suis vraiment très content de revoir ce projet de nouveau actif !
Il serait peut-être temps de penser à des tests unitaires et de la documentation mais il me faudrait des exemples. Magnifique projet en tout cas !