### PR TITLE
Fix Physics 2D typo and compilation

### DIFF
--- a/include/Nazara/Physics2D.hpp
+++ b/include/Nazara/Physics2D.hpp
@@ -1,7 +1,7 @@
-// This file was automatically generated on 24 Jun 2015 at 13:55:50
+// This file was automatically generated on 14 Oct 2016 at 18:58:18
 
 /*
-	Nazara Engine - Physics module
+	Nazara Engine - Physics 2D module
 
 	Copyright (C) 2015 Jérôme "Lynix" Leclercq (Lynix680@gmail.com)
 
@@ -26,14 +26,14 @@
 
 #pragma once
 
-#ifndef NAZARA_GLOBAL_PHYSICS_HPP
-#define NAZARA_GLOBAL_PHYSICS_HPP
+#ifndef NAZARA_GLOBAL_PHYSICS2D_HPP
+#define NAZARA_GLOBAL_PHYSICS2D_HPP
 
-#include <Nazara/Physics/Config.hpp>
-#include <Nazara/Physics/Enums.hpp>
-#include <Nazara/Physics/Geom.hpp>
-#include <Nazara/Physics/Physics.hpp>
-#include <Nazara/Physics/PhysObject.hpp>
-#include <Nazara/Physics/PhysWorld.hpp>
+#include <Nazara/Physics2D/PhysWorld2D.hpp>
+#include <Nazara/Physics2D/Physics2D.hpp>
+#include <Nazara/Physics2D/Collider2D.hpp>
+#include <Nazara/Physics2D/Enums.hpp>
+#include <Nazara/Physics2D/Config.hpp>
+#include <Nazara/Physics2D/RigidBody2D.hpp>
 
-#endif // NAZARA_GLOBAL_PHYSICS_HPP
+#endif // NAZARA_GLOBAL_PHYSICS2D_HPP

--- a/include/Nazara/Physics2D/Collider2D.inl
+++ b/include/Nazara/Physics2D/Collider2D.inl
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #include <memory>

--- a/include/Nazara/Physics2D/Config.hpp
+++ b/include/Nazara/Physics2D/Config.hpp
@@ -1,5 +1,5 @@
 /*
-	Nazara Engine - Physics 3D module
+	Nazara Engine - Physics 2D module
 
 	Copyright (C) 2015 Jérôme "Lynix" Leclercq (Lynix680@gmail.com)
 

--- a/include/Nazara/Physics2D/ConfigCheck.hpp
+++ b/include/Nazara/Physics2D/ConfigCheck.hpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #pragma once

--- a/include/Nazara/Physics2D/Debug.hpp
+++ b/include/Nazara/Physics2D/Debug.hpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #include <Nazara/Physics3D/Config.hpp>

--- a/include/Nazara/Physics2D/DebugOff.hpp
+++ b/include/Nazara/Physics2D/DebugOff.hpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 // On suppose que Debug.hpp a déjà été inclus, tout comme Config.hpp

--- a/include/Nazara/Physics2D/PhysWorld2D.hpp
+++ b/include/Nazara/Physics2D/PhysWorld2D.hpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #pragma once

--- a/include/Nazara/Physics2D/Physics2D.hpp
+++ b/include/Nazara/Physics2D/Physics2D.hpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #pragma once

--- a/include/Nazara/Physics2D/RigidBody2D.hpp
+++ b/include/Nazara/Physics2D/RigidBody2D.hpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #pragma once

--- a/include/Nazara/Physics3D.hpp
+++ b/include/Nazara/Physics3D.hpp
@@ -1,0 +1,39 @@
+// This file was automatically generated on 14 Oct 2016 at 18:58:18
+
+/*
+	Nazara Engine - Physics 3D module
+
+	Copyright (C) 2015 Jérôme "Lynix" Leclercq (Lynix680@gmail.com)
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy of
+	this software and associated documentation files (the "Software"), to deal in
+	the Software without restriction, including without limitation the rights to
+	use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+	of the Software, and to permit persons to whom the Software is furnished to do
+	so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	SOFTWARE.
+*/
+
+#pragma once
+
+#ifndef NAZARA_GLOBAL_PHYSICS3D_HPP
+#define NAZARA_GLOBAL_PHYSICS3D_HPP
+
+#include <Nazara/Physics3D/PhysWorld3D.hpp>
+#include <Nazara/Physics3D/Physics3D.hpp>
+#include <Nazara/Physics3D/RigidBody3D.hpp>
+#include <Nazara/Physics3D/Enums.hpp>
+#include <Nazara/Physics3D/Config.hpp>
+#include <Nazara/Physics3D/Collider3D.hpp>
+
+#endif // NAZARA_GLOBAL_PHYSICS3D_HPP

--- a/src/Nazara/Physics2D/Collider2D.cpp
+++ b/src/Nazara/Physics2D/Collider2D.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #include <Nazara/Physics2D/Collider2D.hpp>

--- a/src/Nazara/Physics2D/Debug/NewOverload.cpp
+++ b/src/Nazara/Physics2D/Debug/NewOverload.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #include <Nazara/Physics3D/Config.hpp>

--- a/src/Nazara/Physics2D/PhysWorld2D.cpp
+++ b/src/Nazara/Physics2D/PhysWorld2D.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #include <Nazara/Physics2D/PhysWorld2D.hpp>

--- a/src/Nazara/Physics2D/Physics2D.cpp
+++ b/src/Nazara/Physics2D/Physics2D.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #include <Nazara/Physics2D/Physics2D.hpp>

--- a/src/Nazara/Physics2D/RigidBody2D.cpp
+++ b/src/Nazara/Physics2D/RigidBody2D.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2015 Jérôme Leclercq
-// This file is part of the "Nazara Engine - Physics 3D module"
+// This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #include <Nazara/Physics2D/RigidBody2D.hpp>


### PR DESCRIPTION
In files head, change 'Physics 3D module' to 'Physics 2D module' and fix compilation of Physics 2D and 3D