### PR TITLE
Core/*Logger: Make some functions const - Core/Log: Add possibility of setting a default logger (for initialization)

### DIFF
--- a/include/Nazara/Core/AbstractLogger.hpp
+++ b/include/Nazara/Core/AbstractLogger.hpp
@@ -21,7 +21,7 @@ namespace Nz
 
 			virtual void EnableStdReplication(bool enable) = 0;
 
-			virtual bool IsStdReplicationEnabled() = 0;
+			virtual bool IsStdReplicationEnabled() const = 0;
 
 			virtual void Write(const String& string) = 0;
 			virtual void WriteError(ErrorType type, const String& error, unsigned int line = 0, const char* file = nullptr, const char* function = nullptr);

--- a/include/Nazara/Core/FileLogger.hpp
+++ b/include/Nazara/Core/FileLogger.hpp
@@ -26,7 +26,7 @@ namespace Nz
 			void EnableStdReplication(bool enable) override;
 
 			bool IsStdReplicationEnabled() const override;
-			bool IsTimeLoggingEnabled();
+			bool IsTimeLoggingEnabled() const;
 
 			void Write(const String& string) override;
 			void WriteError(ErrorType type, const String& error, unsigned int line = 0, const char* file = nullptr, const char* function = nullptr) override;

--- a/include/Nazara/Core/FileLogger.hpp
+++ b/include/Nazara/Core/FileLogger.hpp
@@ -25,7 +25,7 @@ namespace Nz
 			void EnableTimeLogging(bool enable);
 			void EnableStdReplication(bool enable) override;
 
-			bool IsStdReplicationEnabled() override;
+			bool IsStdReplicationEnabled() const override;
 			bool IsTimeLoggingEnabled();
 
 			void Write(const String& string) override;

--- a/include/Nazara/Core/Log.hpp
+++ b/include/Nazara/Core/Log.hpp
@@ -41,7 +41,6 @@ namespace Nz
 
 			static bool IsEnabled();
 
-			static void SetDefaultLogger(AbstractLogger* defaultLogger);
 			static void SetLogger(AbstractLogger* logger);
 
 			static void Write(const String& string);
@@ -54,7 +53,6 @@ namespace Nz
 			static bool Initialize();
 			static void Uninitialize();
 
-			static AbstractLogger* s_defaultLogger;
 			static AbstractLogger* s_logger;
 			static bool s_enabled;
 	};

--- a/include/Nazara/Core/Log.hpp
+++ b/include/Nazara/Core/Log.hpp
@@ -41,6 +41,7 @@ namespace Nz
 
 			static bool IsEnabled();
 
+			static void SetDefaultLogger(AbstractLogger* defaultLogger);
 			static void SetLogger(AbstractLogger* logger);
 
 			static void Write(const String& string);
@@ -53,6 +54,7 @@ namespace Nz
 			static bool Initialize();
 			static void Uninitialize();
 
+			static AbstractLogger* s_defaultLogger;
 			static AbstractLogger* s_logger;
 			static bool s_enabled;
 	};

--- a/include/Nazara/Core/StdLogger.hpp
+++ b/include/Nazara/Core/StdLogger.hpp
@@ -22,7 +22,7 @@ namespace Nz
 
 			void EnableStdReplication(bool enable) override;
 
-			bool IsStdReplicationEnabled() override;
+			bool IsStdReplicationEnabled() const override;
 
 			void Write(const String& string) override;
 			void WriteError(ErrorType type, const String& error, unsigned int line = 0, const char* file = nullptr, const char* function = nullptr) override;

--- a/src/Nazara/Core/FileLogger.cpp
+++ b/src/Nazara/Core/FileLogger.cpp
@@ -75,7 +75,7 @@ namespace Nz
 	* \return true If logging of the time is enabled
 	*/
 
-	bool FileLogger::IsTimeLoggingEnabled()
+	bool FileLogger::IsTimeLoggingEnabled() const
 	{
 		return m_timeLoggingEnabled;
 	}

--- a/src/Nazara/Core/FileLogger.cpp
+++ b/src/Nazara/Core/FileLogger.cpp
@@ -65,7 +65,7 @@ namespace Nz
 	* \return true If replication is enabled
 	*/
 
-	bool FileLogger::IsStdReplicationEnabled()
+	bool FileLogger::IsStdReplicationEnabled() const
 	{
 		return m_stdReplicationEnabled;
 	}

--- a/src/Nazara/Core/Log.cpp
+++ b/src/Nazara/Core/Log.cpp
@@ -53,6 +53,22 @@ namespace Nz
 	}
 
 	/*!
+	* \brief Sets the default logger
+	*
+	* \param defaultLogger Default AbstractLogger
+	*/
+
+	void Log::SetDefaultLogger(AbstractLogger* defaultLogger)
+	{
+		if (s_defaultLogger != &s_stdLogger)
+			delete s_defaultLogger;
+
+		s_defaultLogger = defaultLogger;
+		if (!s_defaultLogger)
+			s_defaultLogger = &s_stdLogger;
+	}
+
+	/*!
 	* \brief Sets the logger
 	*
 	* \param logger AbstractLogger to log
@@ -111,7 +127,7 @@ namespace Nz
 
 	bool Log::Initialize()
 	{
-		SetLogger(new FileLogger());
+		SetLogger(s_defaultLogger);
 		return true;
 	}
 
@@ -121,12 +137,14 @@ namespace Nz
 
 	void Log::Uninitialize()
 	{
+		SetDefaultLogger(nullptr);
 		SetLogger(nullptr);
 	}
 
 	NazaraStaticSignalImpl(Log, OnLogWrite);
 	NazaraStaticSignalImpl(Log, OnLogWriteError);
 
+	AbstractLogger* Log::s_defaultLogger = &s_stdLogger;
 	AbstractLogger* Log::s_logger = &s_stdLogger;
 	bool Log::s_enabled = true;
 }

--- a/src/Nazara/Core/Log.cpp
+++ b/src/Nazara/Core/Log.cpp
@@ -111,10 +111,8 @@ namespace Nz
 
 	bool Log::Initialize()
 	{
-		if (s_logger == s_stdLogger)
-		{
+		if (s_logger == &s_stdLogger)
 			s_logger = new FileLogger();
-		}
 
 		SetLogger(s_logger);
 		return true;

--- a/src/Nazara/Core/Log.cpp
+++ b/src/Nazara/Core/Log.cpp
@@ -53,22 +53,6 @@ namespace Nz
 	}
 
 	/*!
-	* \brief Sets the default logger
-	*
-	* \param defaultLogger Default AbstractLogger
-	*/
-
-	void Log::SetDefaultLogger(AbstractLogger* defaultLogger)
-	{
-		if (s_defaultLogger != &s_stdLogger)
-			delete s_defaultLogger;
-
-		s_defaultLogger = defaultLogger;
-		if (!s_defaultLogger)
-			s_defaultLogger = &s_stdLogger;
-	}
-
-	/*!
 	* \brief Sets the logger
 	*
 	* \param logger AbstractLogger to log
@@ -127,7 +111,12 @@ namespace Nz
 
 	bool Log::Initialize()
 	{
-		SetLogger(s_defaultLogger);
+		if (s_logger == s_stdLogger)
+		{
+			s_logger = new FileLogger();
+		}
+
+		SetLogger(s_logger);
 		return true;
 	}
 
@@ -137,14 +126,12 @@ namespace Nz
 
 	void Log::Uninitialize()
 	{
-		SetDefaultLogger(nullptr);
 		SetLogger(nullptr);
 	}
 
 	NazaraStaticSignalImpl(Log, OnLogWrite);
 	NazaraStaticSignalImpl(Log, OnLogWriteError);
 
-	AbstractLogger* Log::s_defaultLogger = &s_stdLogger;
 	AbstractLogger* Log::s_logger = &s_stdLogger;
 	bool Log::s_enabled = true;
 }

--- a/src/Nazara/Core/Log.cpp
+++ b/src/Nazara/Core/Log.cpp
@@ -112,9 +112,8 @@ namespace Nz
 	bool Log::Initialize()
 	{
 		if (s_logger == &s_stdLogger)
-			s_logger = new FileLogger();
+			SetLogger(new FileLogger());
 
-		SetLogger(s_logger);
 		return true;
 	}
 

--- a/src/Nazara/Core/StdLogger.cpp
+++ b/src/Nazara/Core/StdLogger.cpp
@@ -47,7 +47,7 @@ namespace Nz
 	* \return Always returns true
 	*/
 
-	bool StdLogger::IsStdReplicationEnabled()
+	bool StdLogger::IsStdReplicationEnabled() const
 	{
 		return true;
 	}


### PR DESCRIPTION
Make `AbstractLogger::IsStdReplicationEnabled` and `FileLogger::IsTimeLoggingEnabled` const
We can now set a default logger who is set in initializer (instead of always a FileLogger)