### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme_fr.md
+++ b/readme_fr.md
@@ -43,7 +43,7 @@ Vous pouvez lire des tutoriaux sur l'installation, la compilation et l'utilisati
 [Wiki](https://github.com/DigitalPulseSoftware/NazaraEngine/wiki)  
 [Forum](https://forum.digitalpulsesoftware.net)  
 
-###Remerciements:
+### Remerciements:
 
 - **RafBill** et **Raakz:** Recherche de bugs et/ou tests  
 - **Fissal "DrFisher" Hannoun**: Aide et conseils lors de la conception de l'architecture du moteur  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
