### PR TITLE
Physics2D change

### DIFF
--- a/SDK/src/NDK/Components/CollisionComponent2D.cpp
+++ b/SDK/src/NDK/Components/CollisionComponent2D.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Jérôme Leclercq
+﻿// Copyright (C) 2017 Jérôme Leclercq
 // This file is part of the "Nazara Development Kit"
 // For conditions of distribution and use, see copyright notice in Prerequesites.hpp
 
@@ -58,7 +58,7 @@ namespace Ndk
 		NazaraAssert(entityWorld->HasSystem<PhysicsSystem2D>(), "World must have a physics system");
 		Nz::PhysWorld2D& physWorld = entityWorld->GetSystem<PhysicsSystem2D>().GetWorld();
 
-		m_staticBody.reset(new Nz::RigidBody2D(&physWorld, 0.f, m_geom));
+		m_staticBody.reset(new Nz::RigidBody2D(&physWorld, 1.f, m_geom));
 
 		Nz::Matrix4f matrix;
 		if (m_entity->HasComponent<NodeComponent>())

--- a/SDK/src/NDK/Components/CollisionComponent2D.cpp
+++ b/SDK/src/NDK/Components/CollisionComponent2D.cpp
@@ -58,7 +58,7 @@ namespace Ndk
 		NazaraAssert(entityWorld->HasSystem<PhysicsSystem2D>(), "World must have a physics system");
 		Nz::PhysWorld2D& physWorld = entityWorld->GetSystem<PhysicsSystem2D>().GetWorld();
 
-		m_staticBody.reset(new Nz::RigidBody2D(&physWorld, 1.f, m_geom));
+		m_staticBody.reset(new Nz::RigidBody2D(&physWorld, 0.f, m_geom));
 
 		Nz::Matrix4f matrix;
 		if (m_entity->HasComponent<NodeComponent>())

--- a/include/Nazara/Physics2D/Collider2D.hpp
+++ b/include/Nazara/Physics2D/Collider2D.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Jérôme Leclercq
+﻿// Copyright (C) 2017 Jérôme Leclercq
 // This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
@@ -148,6 +148,7 @@ namespace Nz
 
 		private:
 			void CreateShapes(RigidBody2D* body, std::vector<cpShape*>& shapes) const override;
+			std::vector<cpShape*> GenerateShapes(RigidBody2D* body) const override;
 
 			std::vector<Collider2DRef> m_geoms;
 	};

--- a/src/Nazara/Physics2D/Collider2D.cpp
+++ b/src/Nazara/Physics2D/Collider2D.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Jérôme Leclercq
+﻿// Copyright (C) 2017 Jérôme Leclercq
 // This file is part of the "Nazara Engine - Physics 2D module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
@@ -107,6 +107,17 @@ namespace Nz
 		// Since C++ does not allow protected call from other objects, we have to be a friend of Collider2D, yay
 		for (const auto& geom : m_geoms)
 			geom->CreateShapes(body, shapes);
+	}
+
+	std::vector<cpShape*> CompoundCollider2D::GenerateShapes(RigidBody2D * body) const
+	{
+		std::vector<cpShape*> shapes;
+		for (const auto& geom : m_geoms)
+		{
+			const auto& tempShapes = geom->GenerateShapes(body);
+			shapes.insert(shapes.end(), tempShapes.begin(), tempShapes.end());
+		}
+		return shapes;
 	}
 
 	/******************************** ConvexCollider2D *********************************/


### PR DESCRIPTION
- Fix 0 mass error for a Collider2D without a PhysicComponent2D
- Remove ColliderID overwrite for CompoundCollider2D