### PR TITLE
Fix unwanted behavior with universal references

### DIFF
--- a/include/Nazara/Lua/LuaState.hpp
+++ b/include/Nazara/Lua/LuaState.hpp
@@ -134,7 +134,6 @@ namespace Nz
 			template<typename R, typename... Args, typename... DefArgs> void PushFunction(R(*func)(Args...), DefArgs&&... defArgs) const;
 			template<typename T> void PushGlobal(const char* name, T&& arg);
 			template<typename T> void PushGlobal(const String& name, T&& arg);
-			template<typename T> void PushInstance(const char* tname, const T& instance) const;
 			template<typename T> void PushInstance(const char* tname, T&& instance) const;
 			template<typename T, typename... Args> void PushInstance(const char* tname, Args&&... args) const;
 			void PushInteger(long long value) const;

--- a/include/Nazara/Lua/LuaState.inl
+++ b/include/Nazara/Lua/LuaState.inl
@@ -743,15 +743,6 @@ namespace Nz
 	}
 
 	template<typename T>
-	void LuaState::PushInstance(const char* tname, const T& instance) const
-	{
-		T* userdata = static_cast<T*>(PushUserdata(sizeof(T)));
-		PlacementNew(userdata, instance);
-
-		SetMetatable(tname);
-	}
-
-	template<typename T>
 	void LuaState::PushInstance(const char* tname, T&& instance) const
 	{
 		T* userdata = static_cast<T*>(PushUserdata(sizeof(T)));


### PR DESCRIPTION
The code's behavior would be to copy the object then move it, but it actually didn't copy it