### PR TITLE
TextAreaWidget: Implement movement with Ctrl key

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -129,6 +129,7 @@ Nazara Engine:
 - Fixed bug in ENet implementation causing legit reliable packets to be dropped on sequence number overflow
 - Fixed bug where index wouldn't be used in String::FindLast and String::FindWord
 - Physics 2D contact callbacks now include an arbiter allowing to query/set parameters about the collision
+- Added movement with Ctrl in TextAreaWidget
 
 Nazara Development Kit:
 - Added ImageWidget (#139)

--- a/SDK/src/NDK/Widgets/TextAreaWidget.cpp
+++ b/SDK/src/NDK/Widgets/TextAreaWidget.cpp
@@ -253,17 +253,6 @@ namespace Ndk
 				if (ignoreDefaultAction)
 					return true;
 
-				/*if (HasSelection())
-					SetCursorPosition(m_cursorPositionBegin);
-				else
-					if (key.control)
-					{
-						std::size_t index = GetGlyphIndex(m_cursorPositionBegin);
-						std::size_t spaceIndex = m_text.Find(' ', index);
-					}
-					else
-						MoveCursor(-1);*/
-
 				if (HasSelection())
 					SetCursorPosition(m_cursorPositionBegin);
 				else

--- a/SDK/src/NDK/Widgets/TextAreaWidget.cpp
+++ b/SDK/src/NDK/Widgets/TextAreaWidget.cpp
@@ -245,7 +245,7 @@ namespace Ndk
 				return true;
 			}
 
-			case Nz::Keyboard::Left: //avant
+			case Nz::Keyboard::Left:
 			{
 				bool ignoreDefaultAction = false;
 				OnTextAreaKeyLeft(this, &ignoreDefaultAction);
@@ -255,31 +255,30 @@ namespace Ndk
 
 				if (HasSelection())
 					SetCursorPosition(m_cursorPositionBegin);
-				else
-					if (key.control)
+				else if (key.control)
+				{
+					std::size_t index = GetGlyphIndex(m_cursorPositionBegin);
+
+					if (index == 0)
+						return true;
+
+					std::size_t spaceIndex = m_text.FindLast(' ', index - 2);
+					std::size_t endlIndex = m_text.FindLast('\n', index - 1);
+
+					if ((spaceIndex > endlIndex || endlIndex == Nz::String::npos) && spaceIndex != Nz::String::npos)
+						SetCursorPosition(spaceIndex + 1);
+					else if (endlIndex != Nz::String::npos)
 					{
-						std::size_t index = GetGlyphIndex(m_cursorPositionBegin);
-
-						if (index == 0)
-							return true;
-
-						std::size_t spaceIndex = m_text.FindLast(' ', index - 2);
-						std::size_t endlIndex = m_text.FindLast('\n', index - 1);
-
-						if ((spaceIndex > endlIndex || endlIndex == Nz::String::npos) && spaceIndex != Nz::String::npos)
-							SetCursorPosition(spaceIndex + 1);
-						else if (endlIndex != Nz::String::npos)
-						{
-							if (index == endlIndex + 1)
-								SetCursorPosition(endlIndex);
-							else
-								SetCursorPosition(endlIndex + 1);
-						}
+						if (index == endlIndex + 1)
+							SetCursorPosition(endlIndex);
 						else
-							SetCursorPosition({ 0U, m_cursorPositionBegin.y });
+							SetCursorPosition(endlIndex + 1);
 					}
 					else
-						MoveCursor(-1);
+						SetCursorPosition({ 0U, m_cursorPositionBegin.y });
+				}
+				else
+					MoveCursor(-1);
 
 				return true;
 			}
@@ -294,32 +293,31 @@ namespace Ndk
 
 				if (HasSelection())
 					SetCursorPosition(m_cursorPositionEnd);
-				else
-					if (key.control)
-					{
-						std::size_t index = GetGlyphIndex(m_cursorPositionEnd);
-						std::size_t spaceIndex = m_text.Find(' ', index);
-						std::size_t endlIndex = m_text.Find('\n', index);
+				else if (key.control)
+				{
+					std::size_t index = GetGlyphIndex(m_cursorPositionEnd);
+					std::size_t spaceIndex = m_text.Find(' ', index);
+					std::size_t endlIndex = m_text.Find('\n', index);
 
-						if (spaceIndex < endlIndex && spaceIndex != Nz::String::npos)
-						{
-							if (m_text.GetSize() > spaceIndex)
-								SetCursorPosition(spaceIndex + 1);
-							else
-								SetCursorPosition({ static_cast<unsigned int>(m_drawer.GetLineGlyphCount(m_cursorPositionEnd.y)), m_cursorPositionEnd.y });
-						}
-						else if (endlIndex != Nz::String::npos)
-						{
-							if (index == endlIndex)
-								SetCursorPosition(endlIndex + 1);
-							else
-								SetCursorPosition(endlIndex);
-						}
+					if (spaceIndex < endlIndex && spaceIndex != Nz::String::npos)
+					{
+						if (m_text.GetSize() > spaceIndex)
+							SetCursorPosition(spaceIndex + 1);
 						else
 							SetCursorPosition({ static_cast<unsigned int>(m_drawer.GetLineGlyphCount(m_cursorPositionEnd.y)), m_cursorPositionEnd.y });
 					}
+					else if (endlIndex != Nz::String::npos)
+					{
+						if (index == endlIndex)
+							SetCursorPosition(endlIndex + 1);
+						else
+							SetCursorPosition(endlIndex);
+					}
 					else
-						MoveCursor(1);
+						SetCursorPosition({ static_cast<unsigned int>(m_drawer.GetLineGlyphCount(m_cursorPositionEnd.y)), m_cursorPositionEnd.y });
+				}
+				else
+					MoveCursor(1);
 
 				return true;
 			}

--- a/SDK/src/NDK/Widgets/TextAreaWidget.cpp
+++ b/SDK/src/NDK/Widgets/TextAreaWidget.cpp
@@ -224,8 +224,12 @@ namespace Ndk
 				if (ignoreDefaultAction)
 					return true;
 
-				const auto& lineInfo = m_drawer.GetLine(m_cursorPositionEnd.y);
-				SetCursorPosition({ static_cast<unsigned int>(m_drawer.GetLineGlyphCount(m_cursorPositionEnd.y)), m_cursorPositionEnd.y });
+				std::size_t lineCount = m_drawer.GetLineCount();
+				if (key.control && lineCount > 0)
+					SetCursorPosition({ static_cast<unsigned int>(m_drawer.GetLineGlyphCount(lineCount - 1)), static_cast<unsigned int>(lineCount - 1) });
+				else
+					SetCursorPosition({ static_cast<unsigned int>(m_drawer.GetLineGlyphCount(m_cursorPositionEnd.y)), m_cursorPositionEnd.y });
+
 				return true;
 			}
 
@@ -237,11 +241,11 @@ namespace Ndk
 				if (ignoreDefaultAction)
 					return true;
 
-				SetCursorPosition({ 0U, m_cursorPositionEnd.y });
+				SetCursorPosition({ 0U, key.control ? 0U : m_cursorPositionEnd.y });
 				return true;
 			}
 
-			case Nz::Keyboard::Left:
+			case Nz::Keyboard::Left: //avant
 			{
 				bool ignoreDefaultAction = false;
 				OnTextAreaKeyLeft(this, &ignoreDefaultAction);
@@ -249,10 +253,44 @@ namespace Ndk
 				if (ignoreDefaultAction)
 					return true;
 
+				/*if (HasSelection())
+					SetCursorPosition(m_cursorPositionBegin);
+				else
+					if (key.control)
+					{
+						std::size_t index = GetGlyphIndex(m_cursorPositionBegin);
+						std::size_t spaceIndex = m_text.Find(' ', index);
+					}
+					else
+						MoveCursor(-1);*/
+
 				if (HasSelection())
 					SetCursorPosition(m_cursorPositionBegin);
 				else
-					MoveCursor(-1);
+					if (key.control)
+					{
+						std::size_t index = GetGlyphIndex(m_cursorPositionBegin);
+
+						if (index == 0)
+							return true;
+
+						std::size_t spaceIndex = m_text.FindLast(' ', index - 2);
+						std::size_t endlIndex = m_text.FindLast('\n', index - 1);
+
+						if ((spaceIndex > endlIndex || endlIndex == Nz::String::npos) && spaceIndex != Nz::String::npos)
+							SetCursorPosition(spaceIndex + 1);
+						else if (endlIndex != Nz::String::npos)
+						{
+							if (index == endlIndex + 1)
+								SetCursorPosition(endlIndex);
+							else
+								SetCursorPosition(endlIndex + 1);
+						}
+						else
+							SetCursorPosition({ 0U, m_cursorPositionBegin.y });
+					}
+					else
+						MoveCursor(-1);
 
 				return true;
 			}
@@ -268,7 +306,31 @@ namespace Ndk
 				if (HasSelection())
 					SetCursorPosition(m_cursorPositionEnd);
 				else
-					MoveCursor(1);
+					if (key.control)
+					{
+						std::size_t index = GetGlyphIndex(m_cursorPositionEnd);
+						std::size_t spaceIndex = m_text.Find(' ', index);
+						std::size_t endlIndex = m_text.Find('\n', index);
+
+						if (spaceIndex < endlIndex && spaceIndex != Nz::String::npos)
+						{
+							if (m_text.GetSize() > spaceIndex)
+								SetCursorPosition(spaceIndex + 1);
+							else
+								SetCursorPosition({ static_cast<unsigned int>(m_drawer.GetLineGlyphCount(m_cursorPositionEnd.y)), m_cursorPositionEnd.y });
+						}
+						else if (endlIndex != Nz::String::npos)
+						{
+							if (index == endlIndex)
+								SetCursorPosition(endlIndex + 1);
+							else
+								SetCursorPosition(endlIndex);
+						}
+						else
+							SetCursorPosition({ static_cast<unsigned int>(m_drawer.GetLineGlyphCount(m_cursorPositionEnd.y)), m_cursorPositionEnd.y });
+					}
+					else
+						MoveCursor(1);
 
 				return true;
 			}


### PR DESCRIPTION
Currently, you can only move from spaces/line end to next space/line end