### PR TITLE
unicode: silence shadow variable warnings

### DIFF
--- a/src/Nazara/Core/Unicode.cpp
+++ b/src/Nazara/Core/Unicode.cpp
@@ -37,13 +37,13 @@ namespace Nz
 	{
 		const UnicodeCharacter* GetCharacter(Nz::UInt32 codepoint)
 		{
-			auto it = std::lower_bound(std::begin(unicodeCharacters), std::end(unicodeCharacters), codepoint, [](const UnicodeCharacter& character, Nz::UInt32 codepoint) { return character.codepoint < codepoint; });
+			auto it = std::lower_bound(std::begin(unicodeCharacters), std::end(unicodeCharacters), codepoint, [](const UnicodeCharacter& character, Nz::UInt32 otherCodepoint) { return character.codepoint < otherCodepoint; });
 			if (it != std::end(unicodeCharacters) && it->codepoint == codepoint)
 				return &*it;
 			else
 			{
 				// Character is not part of the common character array, search in set
-				auto itSet = std::lower_bound(std::begin(unicodeSets), std::end(unicodeSets), codepoint, [](const UnicodeSet& character, Nz::UInt32 codepoint) { return character.firstCodepoint < codepoint; });
+				auto itSet = std::lower_bound(std::begin(unicodeSets), std::end(unicodeSets), codepoint, [](const UnicodeSet& character, Nz::UInt32 otherCodepoint) { return character.firstCodepoint < otherCodepoint; });
 				if (itSet != std::begin(unicodeSets))
 				{
 					--itSet;
@@ -58,7 +58,7 @@ namespace Nz
 		template<std::size_t N>
 		const UnicodeCharacterSimpleMapping* GetCharacterMapping(Nz::UInt32 codepoint, const UnicodeCharacterSimpleMapping(&mapping)[N])
 		{
-			auto it = std::lower_bound(std::begin(mapping), std::end(mapping), codepoint, [](const UnicodeCharacterSimpleMapping& character, Nz::UInt32 codepoint) { return character.codepoint < codepoint; });
+			auto it = std::lower_bound(std::begin(mapping), std::end(mapping), codepoint, [](const UnicodeCharacterSimpleMapping& character, Nz::UInt32 otherCodepoint) { return character.codepoint < otherCodepoint; });
 			if (it != std::end(mapping) && it->codepoint == codepoint)
 				return &*it;
 			else


### PR DESCRIPTION
Silence these warnings:

```
==== Building NazaraCore (debugdynamic_x64) ====
Unicode.cpp
../../../src/Nazara/Core/Unicode.cpp: In lambda function:
../../../src/Nazara/Core/Unicode.cpp:40:160: warning: declaration of ‘Nz::UInt32 codepoint’ shadows a parameter [-Wshadow]
 begin(unicodeCharacters), std::end(unicodeCharacters), codepoint, [](const UnicodeCharacter& character, Nz::UInt32 codepoint) { return character.codepoint < codepoint; });
                                                                                                                             ^

../../../src/Nazara/Core/Unicode.cpp:38:51: note: shadowed declaration is here
   const UnicodeCharacter* GetCharacter(Nz::UInt32 codepoint)
                                        ~~~~~~~~~~~^~~~~~~~~
../../../src/Nazara/Core/Unicode.cpp: In lambda function:
../../../src/Nazara/Core/Unicode.cpp:46:146: warning: declaration of ‘Nz::UInt32 codepoint’ shadows a parameter [-Wshadow]
 :lower_bound(std::begin(unicodeSets), std::end(unicodeSets), codepoint, [](const UnicodeSet& character, Nz::UInt32 codepoint) { return character.firstCodepoint < codepoint; });
                                                                                                                             ^

../../../src/Nazara/Core/Unicode.cpp:38:51: note: shadowed declaration is here
   const UnicodeCharacter* GetCharacter(Nz::UInt32 codepoint)
                                        ~~~~~~~~~~~^~~~~~~~~
../../../src/Nazara/Core/Unicode.cpp: In lambda function:
../../../src/Nazara/Core/Unicode.cpp:61:153: warning: declaration of ‘Nz::UInt32 codepoint’ shadows a parameter [-Wshadow]
 d(std::begin(mapping), std::end(mapping), codepoint, [](const UnicodeCharacterSimpleMapping& character, Nz::UInt32 codepoint) { return character.codepoint < codepoint; });
                                                                                                                             ^

../../../src/Nazara/Core/Unicode.cpp:59:71: note: shadowed declaration is here
   const UnicodeCharacterSimpleMapping* GetCharacterMapping(Nz::UInt32 codepoint, const UnicodeCharacterSimpleMapping(&mapping)[N])
                                                            ~~~~~~~~~~~^~~~~~~~~
../../../src/Nazara/Core/Unicode.cpp: In instantiation of ‘const Nz::UnicodeCharacterSimpleMapping* Nz::{anonymous}::GetCharacterMapping(Nz::UInt32, const Nz::UnicodeCharacterSimpleMapping (&)[N]) [with long unsigned int N = 1383; Nz::UInt32 = unsigned int]’:
../../../src/Nazara/Core/Unicode.cpp:107:106:   required from here
../../../src/Nazara/Core/Unicode.cpp:61:30: warning: declaration of ‘Nz::UInt32 codepoint’ shadows a parameter [-Wshadow]
    auto it = std::lower_bound(std::begin(mapping), std::end(mapping), codepoint, [](const UnicodeCharacterSimpleMapping& character, Nz::UInt32 codepoint) { return character.codepoint < codepoint; });
              ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../src/Nazara/Core/Unicode.cpp:59:71: note: shadowed declaration is here
   const UnicodeCharacterSimpleMapping* GetCharacterMapping(Nz::UInt32 codepoint, const UnicodeCharacterSimpleMapping(&mapping)[N])
                                                            ~~~~~~~~~~~^~~~~~~~~
../../../src/Nazara/Core/Unicode.cpp: In instantiation of ‘const Nz::UnicodeCharacterSimpleMapping* Nz::{anonymous}::GetCharacterMapping(Nz::UInt32, const Nz::UnicodeCharacterSimpleMapping (&)[N]) [with long unsigned int N = 1404; Nz::UInt32 = unsigned int]’:
../../../src/Nazara/Core/Unicode.cpp:121:106:   required from here
../../../src/Nazara/Core/Unicode.cpp:61:30: warning: declaration of ‘Nz::UInt32 codepoint’ shadows a parameter [-Wshadow]
    auto it = std::lower_bound(std::begin(mapping), std::end(mapping), codepoint, [](const UnicodeCharacterSimpleMapping& character, Nz::UInt32 codepoint) { return character.codepoint < codepoint; });
              ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../src/Nazara/Core/Unicode.cpp:59:71: note: shadowed declaration is here
   const UnicodeCharacterSimpleMapping* GetCharacterMapping(Nz::UInt32 codepoint, const UnicodeCharacterSimpleMapping(&mapping)[N])
                                                            ~~~~~~~~~~~^~~~~~~~~
../../../src/Nazara/Core/Unicode.cpp: In instantiation of ‘const Nz::UnicodeCharacterSimpleMapping* Nz::{anonymous}::GetCharacterMapping(Nz::UInt32, const Nz::UnicodeCharacterSimpleMapping (&)[N]) [with long unsigned int N = 1400; Nz::UInt32 = unsigned int]’:
../../../src/Nazara/Core/Unicode.cpp:135:106:   required from here
../../../src/Nazara/Core/Unicode.cpp:61:30: warning: declaration of ‘Nz::UInt32 codepoint’ shadows a parameter [-Wshadow]
    auto it = std::lower_bound(std::begin(mapping), std::end(mapping), codepoint, [](const UnicodeCharacterSimpleMapping& character, Nz::UInt32 codepoint) { return character.codepoint < codepoint; });
              ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../src/Nazara/Core/Unicode.cpp:59:71: note: shadowed declaration is here
   const UnicodeCharacterSimpleMapping* GetCharacterMapping(Nz::UInt32 codepoint, const UnicodeCharacterSimpleMapping(&mapping)[N])
                                                            ~~~~~~~~~~~^~~~~~~~~```
